### PR TITLE
added error handling at cron hook to avoid crashing cron job

### DIFF
--- a/modules/servers/openprovidersslnew/hooks.php
+++ b/modules/servers/openprovidersslnew/hooks.php
@@ -19,12 +19,16 @@ add_hook('CancelOrder', 1, function ($parameters) {
 });
 
 add_hook('PreCronJob', 1, function () {
-    $orders = Capsule::table('openprovidersslnew_orders')->where('status', ['PAI', 'REQ', 'REJ'])->get();
+    try {
+        $orders = Capsule::table('openprovidersslnew_orders')->where('status', ['PAI', 'REQ', 'REJ'])->get();
 
-    foreach ($orders as $order) {
-        $service = Capsule::table('tblhosting')->where('id', $order->service_id)->first();
-        $product = Capsule::table('tblproducts')->where('id', $service->packageid)->first();
+        foreach ($orders as $order) {
+            $service = Capsule::table('tblhosting')->where('id', $order->service_id)->first();
+            $product = Capsule::table('tblproducts')->where('id', $service->packageid)->first();
 
-        updateOpOrdersTable(array_merge((array)$product, ['id' => $order->order_id, 'serviceid' => $service->id]));
+            updateOpOrdersTable(array_merge((array)$product, ['id' => $order->order_id, 'serviceid' => $service->id]));
+        }
+    } catch (Exception $e) {
+        echo $e->getMessage();
     }
 });


### PR DESCRIPTION
I have added try catch block to handle error during cron job in case the user accidentally deleted the password or the username or the api url from the module settings.

This solution resolves issue that crashing all cron jobs when module throws an error.