### PR TITLE
added fix for not found page

### DIFF
--- a/modules/servers/openprovidersslnew/openprovidersslnew.php
+++ b/modules/servers/openprovidersslnew/openprovidersslnew.php
@@ -9,6 +9,8 @@ if (!defined('WHMCS')) {
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/functions.php';
 
+const PAGE_GENERATE_SSL_PANEL_OTP_TOKEN = 'generateSslPanelOtpToken.php';
+
 /**
  * @return array
  */
@@ -183,11 +185,14 @@ function openprovidersslnew_ClientArea($params)
         'ACT' => 'Active',
     ];
 
+    $scriptFileName = $_SERVER['SCRIPT_NAME'];
+    $prefix = substr($scriptFileName, 0, strlen(basename($scriptFileName)) * -1);
+
     return [
         'templatefile' => 'templates/clientarea.tpl',
         'templateVariables' => [
-            'linkValue' => 'serviceId=' . $params['serviceid'],
             'linkName' => 'SSL Panel',
+            'linkUrl' => $prefix . PAGE_GENERATE_SSL_PANEL_OTP_TOKEN . '?serviceId=' . $params['serviceid'],
             'errorMessage' => $fullMessage,
             'status' => ArrayHelper::getValue($statusMap, $updatedData['status']),
             'creationDate' => $updatedData['creationDate'],

--- a/modules/servers/openprovidersslnew/templates/clientarea.tpl
+++ b/modules/servers/openprovidersslnew/templates/clientarea.tpl
@@ -11,7 +11,7 @@
                         <tr>
                             <td class="fieldarea" width="150">{$linkName}:</td>
                             <td>
-                                <a href="/generateSslPanelOtpToken.php?{$linkValue}"
+                                <a href="{$linkUrl}"
                                    target="_blank">Open</a></td>
                         </tr>
                         <tr>


### PR DESCRIPTION
I assume the issue is different root path on site.
Some of customers have different root path, but the button on the templeta redirect to root path without prefix. This case return undefined page:
![image](https://user-images.githubusercontent.com/51438569/132681647-c204d1a2-f471-4b62-bd75-6b174e9ae81b.png)

![image](https://user-images.githubusercontent.com/51438569/132681672-38474b99-b39e-4b5b-9934-94bb30d395c0.png)

